### PR TITLE
docs: fix Java interop examples and add compilation tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,17 @@ A Kotlin-first SDK for interacting with [Firecracker microVMs](https://firecrack
 import org.firecracker.sdk.*
 
 // Create a VM using the DSL builder
-val vm = Firecracker.build {
-    kernelPath = "/path/to/vmlinux"
-    machineConfig {
-        vcpuCount = 2
-        memSizeMib = 512
-    }
+val vm = Firecracker.createVM {
+    name = "kotlin-vm"
+    kernel = "/path/to/vmlinux"
+    vcpus = 2
+    memory = 512
+
     rootDrive("/path/to/rootfs.ext4")
-    networkInterface {
-        interfaceId = "eth0"
-        hostDevName = "tap0"
+
+    addNetworkInterface {
+        interfaceId("eth0")
+        hostDevice("tap0")
     }
 }
 
@@ -50,17 +51,25 @@ vm.start().onSuccess {
 ```java
 import org.firecracker.sdk.*;
 
-// Create VM with builder pattern
-VirtualMachine vm = Firecracker.builder()
-    .kernelPath("/path/to/vmlinux")
-    .machineConfig(config -> config
-        .vcpuCount(2)
-        .memSizeMib(512))
-    .rootDrive("/path/to/rootfs.ext4")
-    .networkInterface(net -> net
-        .interfaceId("eth0")
-        .hostDevName("tap0"))
-    .build();
+// Create VM using Kotlin DSL from Java
+VirtualMachine vm = Firecracker.INSTANCE.createVM(builder -> {
+    builder.setName("java-vm");
+    builder.setKernel("/path/to/vmlinux");
+    builder.setVcpus(2);
+    builder.setMemory(512);
+
+    // Use convenience method for root drive
+    builder.rootDrive("/path/to/rootfs.ext4", false);
+
+    // Network configuration using builder function
+    builder.addNetworkInterface(net -> {
+        net.interfaceId("eth0");
+        net.hostDevice("tap0");
+        return null; // Required for Java lambda
+    });
+
+    return null; // Required for Java lambda
+});
 
 // Start the VM with Result handling
 vm.start()

--- a/lib/src/test/java/org/firecracker/sdk/examples/JavaReadmeExamplesTest.java
+++ b/lib/src/test/java/org/firecracker/sdk/examples/JavaReadmeExamplesTest.java
@@ -1,0 +1,56 @@
+package org.firecracker.sdk.examples;
+
+import org.firecracker.sdk.Firecracker;
+import org.firecracker.sdk.VirtualMachine;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Java test class to verify that the README Java examples compile correctly.
+ * These tests don't actually run the VMs, just verify the syntax is correct.
+ */
+public class JavaReadmeExamplesTest {
+
+    @Test
+    public void testJavaExample() {
+        // Corrected Java example - accessing Kotlin object properly
+        VirtualMachine vm = Firecracker.INSTANCE.createVM(builder -> {
+            builder.setName("java-vm");
+            builder.setKernel("/path/to/vmlinux");
+            builder.setVcpus(2);
+            builder.setMemory(512);
+
+            // Use convenience method for root drive (needs both path and readonly flag)
+            builder.rootDrive("/path/to/rootfs.ext4", false);
+
+            // Network configuration using builder function
+            builder.addNetworkInterface(net -> {
+                net.interfaceId("eth0");
+                net.hostDevice("tap0");
+                return null; // Required for Java lambda
+            });
+
+            return null; // Required for Java lambda
+        });
+
+        // Just verify it was created (won't actually start without real paths)
+        assertNotNull(vm);
+        assertEquals("java-vm", vm.getName());
+    }
+
+    @Test
+    public void testSimplestJavaExample() {
+        // Simplest possible Java example
+        VirtualMachine vm = Firecracker.INSTANCE.createVM(builder -> {
+            builder.setName("simple-vm");
+            builder.setKernel("/path/to/vmlinux");
+            builder.rootDrive("/path/to/rootfs.ext4", false);
+            return null;
+        });
+
+        assertNotNull(vm);
+        assertEquals("simple-vm", vm.getName());
+    }
+}

--- a/lib/src/test/kotlin/org/firecracker/sdk/examples/ReadmeExamplesTest.kt
+++ b/lib/src/test/kotlin/org/firecracker/sdk/examples/ReadmeExamplesTest.kt
@@ -1,0 +1,63 @@
+package org.firecracker.sdk.examples
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.firecracker.sdk.Firecracker
+
+/**
+ * Test class to verify that the README examples compile correctly.
+ * These tests don't actually run the VMs, just verify the syntax is correct.
+ */
+class ReadmeExamplesTest : DescribeSpec({
+
+    describe("README Examples") {
+
+        it("Kotlin example should compile") {
+            // This is the exact example from README
+            val vm =
+                Firecracker.createVM {
+                    name = "test-vm"
+                    kernel = "/path/to/vmlinux"
+                    vcpus = 2
+                    memory = 512
+
+                    rootDrive("/path/to/rootfs.ext4")
+
+                    addNetworkInterface {
+                        interfaceId("eth0")
+                        hostDevice("tap0")
+                    }
+                }
+
+            // Just verify it was created (won't actually start without real paths)
+            vm shouldNotBe null
+            vm.name shouldBe "test-vm"
+        }
+
+        it("Java-style example should compile") {
+            // This verifies the Java syntax from README works
+            // Note: In Kotlin, we still use the DSL syntax, but assign to properties like Java would
+            val vm =
+                Firecracker.createVM {
+                    name = "java-vm"
+                    kernel = "/path/to/vmlinux"
+                    vcpus = 2
+                    memory = 512
+
+                    // Use convenience method for root drive
+                    rootDrive("/path/to/rootfs.ext4")
+
+                    // Network configuration using builder function
+                    addNetworkInterface {
+                        interfaceId("eth0")
+                        hostDevice("tap0")
+                    }
+                }
+
+            // Just verify it was created
+            vm shouldNotBe null
+            vm.name shouldBe "java-vm"
+        }
+    }
+})


### PR DESCRIPTION
- Correct Java usage to use Firecracker.INSTANCE.createVM()
- Fix VMBuilder property access with setter methods
- Fix rootDrive() method signature (requires boolean parameter)
- Add ReadmeExamplesTest.kt to verify Kotlin examples compile
- Add JavaReadmeExamplesTest.java to verify Java examples compile
- All examples now successfully compile and pass tests