### PR TITLE
deps(deps): bump ktor from 2.3.12 to 3.3.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,10 +2,10 @@
 # This file defines all dependencies and versions for the Firecracker Kotlin/Java SDK
 
 [versions]
-kotlin = "2.0.21"
+kotlin = "2.2.0"
 ktor = "3.3.0"
-kotlinx-serialization = "1.7.3"
-kotlinx-coroutines = "1.8.1"
+kotlinx-serialization = "1.9.0"
+kotlinx-coroutines = "1.9.0"
 jnr-unixsocket = "0.38.21"
 kotlin-logging = "5.1.1"
 logback = "1.4.14"


### PR DESCRIPTION
Bumps `ktor` from 2.3.12 to 3.3.0.

Updates `io.ktor:ktor-client-core` from 2.3.12 to 3.3.0
- [Release notes](https://github.com/ktorio/ktor/releases)
- [Changelog](https://github.com/ktorio/ktor/blob/main/CHANGELOG.md)
- [Commits](https://github.com/ktorio/ktor/compare/2.3.12...3.3.0)

Updates `io.ktor:ktor-client-cio` from 2.3.12 to 3.3.0
- [Release notes](https://github.com/ktorio/ktor/releases)
- [Changelog](https://github.com/ktorio/ktor/blob/main/CHANGELOG.md)
- [Commits](https://github.com/ktorio/ktor/compare/2.3.12...3.3.0)

Updates `io.ktor:ktor-client-content-negotiation` from 2.3.12 to 3.3.0
- [Release notes](https://github.com/ktorio/ktor/releases)
- [Changelog](https://github.com/ktorio/ktor/blob/main/CHANGELOG.md)
- [Commits](https://github.com/ktorio/ktor/compare/2.3.12...3.3.0)

Updates `io.ktor:ktor-serialization-kotlinx-json` from 2.3.12 to 3.3.0
- [Release notes](https://github.com/ktorio/ktor/releases)
- [Changelog](https://github.com/ktorio/ktor/blob/main/CHANGELOG.md)
- [Commits](https://github.com/ktorio/ktor/compare/2.3.12...3.3.0)

---
updated-dependencies:
- dependency-name: io.ktor:ktor-client-core dependency-version: 3.3.0 dependency-type: direct:production update-type: version-update:semver-major
- dependency-name: io.ktor:ktor-client-cio dependency-version: 3.3.0 dependency-type: direct:production update-type: version-update:semver-major
- dependency-name: io.ktor:ktor-client-content-negotiation dependency-version: 3.3.0 dependency-type: direct:production update-type: version-update:semver-major
- dependency-name: io.ktor:ktor-serialization-kotlinx-json dependency-version: 3.3.0 dependency-type: direct:production update-type: version-update:semver-major ...